### PR TITLE
Fix timezone parsing error

### DIFF
--- a/tools/parse.py
+++ b/tools/parse.py
@@ -38,7 +38,7 @@ def date(x):
     """
     Converts Facebook date strings to datetime objects
     """
-    return dt.strptime(x.split(' UTC')[0], '%A, %B %d, %Y at %I:%M%p')
+    return dt.strptime(x.split(' UTC')[0], '%A, %B %d, %Y at %I:%M%p %Z')
 
 
 def thread_parse(file_path):


### PR DESCRIPTION
As of when I checked today, the dates include the timezone tacked onto the end of the string. Without this small fix, unused timezone characters cause the program to die.